### PR TITLE
Update aws client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.jar
 *.war
 *.ear
+*.iml
+
+# Package Folders #
+.idea
+target

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.gu</groupId>
   <artifactId>kinesis-logback-appender</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 
   <name>LOGBack Appender for pushing logs to Kinesis</name>
   <description>This is an implementation of the AWS - Labs log4j appender for LOGBack.</description>
@@ -138,7 +138,17 @@
 
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-kinesis</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>
 
@@ -154,9 +164,9 @@
     <general.encoding>UTF-8</general.encoding>
     
     <!-- JAVA -->
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
-    <aws-java-sdk.version>1.9.24</aws-java-sdk.version>
+    <aws-java-sdk.version>1.10.37</aws-java-sdk.version>
     <logback.version>1.1.3</logback.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
   </properties>

--- a/src/main/java/com/gu/logback/appender/kinesis/AppenderConstants.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/AppenderConstants.java
@@ -20,11 +20,10 @@ import com.amazonaws.regions.Regions;
  * Contains constants and default configuration values for the appender
  */
 public class AppenderConstants {
-  public static final String USER_AGENT_STRING = "kinesis-logback-appender/1.1.0";
+  public static final String USER_AGENT_STRING = "kinesis-logback-appender/1.2.0";
   // Default values
   public static final String DEFAULT_ENCODING = "UTF-8";
   public static final int DEFAULT_MAX_RETRY_COUNT = 3;
-  public static final long DEFAULT_BACKOFF_INTERVAL_MSEC = 100;
   public static final int DEFAULT_BUFFER_SIZE = 2000;
   public static final int DEFAULT_THREAD_COUNT = 20;
   public static final int DEFAULT_SHUTDOWN_TIMEOUT_SEC = 30;

--- a/src/main/java/com/gu/logback/appender/kinesis/KinesisAppender.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/KinesisAppender.java
@@ -124,6 +124,7 @@ public class KinesisAppender extends AppenderBase<ILoggingEvent> {
         if (!regionProvided) {
             region = AppenderConstants.DEFAULT_REGION;
         }
+        kinesisClient.setRegion(Region.getRegion(Regions.fromName(region)));
         if (!Validator.isBlank(endpoint)) {
             if (regionProvided) {
                 addError("Received configuration for both region as well as Amazon Kinesis endpoint. ("
@@ -131,10 +132,7 @@ public class KinesisAppender extends AppenderBase<ILoggingEvent> {
                         + ") will be used as endpoint instead of default endpoint for region ("
                         + region + ")");
             }
-            kinesisClient.setEndpoint(endpoint,
-                    AppenderConstants.DEFAULT_SERVICE_NAME, region);
-        } else {
-            kinesisClient.setRegion(Region.getRegion(Regions.fromName(region)));
+            kinesisClient.setEndpoint(endpoint);
         }
 
         DescribeStreamResult describeResult = null;
@@ -256,8 +254,8 @@ public class KinesisAppender extends AppenderBase<ILoggingEvent> {
      *          encoding for expected log messages
      */
     public void setEncoding(String charset) {
-        Validator.validate(!Validator.isBlank(encoding), "encoding cannot be blank");
-        this.encoding = encoding.trim();
+        Validator.validate(!Validator.isBlank(charset), "encoding cannot be blank");
+        this.encoding = charset.trim();
     }
 
     /**

--- a/src/main/java/com/gu/logback/appender/kinesis/helpers/AsyncPutCallStatsReporter.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/helpers/AsyncPutCallStatsReporter.java
@@ -33,11 +33,10 @@ import com.gu.logback.appender.kinesis.KinesisAppender;
  */
 public class AsyncPutCallStatsReporter implements AsyncHandler<PutRecordRequest, PutRecordResult> {
 
-  private String appenderName;
+  private final String appenderName;
   private long successfulRequestCount;
   private long failedRequestCount;
-  private DateTime startTime;
-  private KinesisAppender appender;
+  private final KinesisAppender appender;
 
   public AsyncPutCallStatsReporter(KinesisAppender appender) {
     this.appenderName = appender.getStreamName();


### PR DESCRIPTION
and fix a few complaints from intellij

The most important change is that it doesn't depend anymore on the whole aws-sdk but only three components used by this library, hence the version update from `1.1.0` to `1.2.0`

@kenoir 