### PR TITLE
Assign the worker threads meaningful names

### DIFF
--- a/src/main/java/com/gu/logback/appender/kinesis/helpers/NamedThreadFactory.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/helpers/NamedThreadFactory.java
@@ -1,0 +1,30 @@
+package com.gu.logback.appender.kinesis.helpers;
+
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread factory that assigns a configurable name to the created threads.
+ *
+ * Delegates thread creation to the {@link Executors#defaultThreadFactory() default thread factory}.
+ */
+public class NamedThreadFactory implements ThreadFactory {
+
+    private final ThreadFactory delegate = Executors.defaultThreadFactory();
+    private final String namePrefix;
+    private final AtomicInteger threadCount = new AtomicInteger(1);
+
+    public NamedThreadFactory(String namePrefix) {
+        this.namePrefix = Objects.requireNonNull(namePrefix);
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        final Thread thread = delegate.newThread(r);
+        thread.setName(namePrefix + threadCount.getAndIncrement());
+        return thread;
+    }
+
+}


### PR DESCRIPTION
By using an explicit ThreadFactory, the worker threads are assigned
meaningful names such that they can be associated with the Kinesis- or
FirehoseAppender.