### PR TITLE
pull in updated version of jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,28 @@
       <version>${logback.version}</version>
     </dependency>
 
+    <!--
+      Pull in an updated version of jackson libraries as the one's AWS use have security vulnerabilities.
+      We cannot simply update the AWS libraries as jackson 2.7+ doesn't support java6 and the AWS libraries compile to java6.
+      See https://github.com/aws/aws-sdk-java/pull/1373
+    -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -229,6 +251,7 @@
     <java.source.encoding>${general.encoding}</java.source.encoding>
     <aws-java-sdk.version>1.11.8</aws-java-sdk.version>
     <logback.version>1.2.3</logback.version>
+    <jackson.version>2.9.2</jackson.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
the one's aws use have vulnerabilities, see https://github.com/aws/aws-sdk-java/pull/1373

tested in MAM in DEV