### PR TITLE
Catch AWS Service Exceptions when initializing appeneder

### DIFF
--- a/src/main/java/com/gu/logback/appender/kinesis/FirehoseAppender.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/FirehoseAppender.java
@@ -18,6 +18,7 @@ package com.gu.logback.appender.kinesis;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsyncClient;
@@ -53,7 +54,7 @@ public class FirehoseAppender<Event extends DeferredProcessingAware>
 
   @Override
   protected void validateStreamName(AmazonKinesisFirehoseAsyncClient client, String streamName) {
-    DescribeDeliveryStreamResult describeResult = null;
+    DescribeDeliveryStreamResult describeResult;
     try {
       describeResult = getClient()
           .describeDeliveryStream(new DescribeDeliveryStreamRequest().withDeliveryStreamName(streamName));
@@ -66,6 +67,10 @@ public class FirehoseAppender<Event extends DeferredProcessingAware>
     catch(ResourceNotFoundException rnfe) {
       setInitializationFailed(true);
       addError("Stream " + streamName + " doesn't exist for appender: " + name, rnfe);
+    }
+    catch(AmazonServiceException ase) {
+      setInitializationFailed(true);
+      addError("Error connecting to AWS to verify stream " + streamName + " for appender: " + name, ase);
     }
   }
 


### PR DESCRIPTION
One example:
```
ERROR in ch.qos.logback.core.joran.spi.Interpreter@33:24 - RuntimeException in Action for tag [appender] com.amazonaws.AmazonServiceException:
User: arn:aws:sts::123123123:assumed-role/ is not authorized to perform: firehose:DescribeDeliveryStream on resource: arn:aws:firehose:eu-west-1:....
(Service: AmazonKinesisFirehose; Status Code: 400; Error Code: AccessDeniedException; Request ID: 782f1dbb-10c7-11e8-bde6-991f2376efb2)
```

Same like for validating empty stream name or missing stream, the error should reported but the app should not be prevented to boot