### PR TITLE
Updated to allow use for ECS (Still falls back to Instance profile)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
     <!-- JAVA -->
     <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
-    <aws-java-sdk.version>1.11.8</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.384</aws-java-sdk.version>
     <logback.version>1.2.3</logback.version>
     <jackson.version>2.9.2</jackson.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>

--- a/src/main/java/com/gu/logback/appender/kinesis/helpers/CustomCredentialsProviderChain.java
+++ b/src/main/java/com/gu/logback/appender/kinesis/helpers/CustomCredentialsProviderChain.java
@@ -17,7 +17,7 @@ package com.gu.logback.appender.kinesis.helpers;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
@@ -34,7 +34,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
  */
 public final class CustomCredentialsProviderChain extends AWSCredentialsProviderChain {
   public CustomCredentialsProviderChain() {
-    super(new ClasspathPropertiesFileCredentialsProvider(), new InstanceProfileCredentialsProvider(),
+    super(new ClasspathPropertiesFileCredentialsProvider(), new EC2ContainerCredentialsProviderWrapper(),
         new SystemPropertiesCredentialsProvider(), new EnvironmentVariableCredentialsProvider(),
         new ProfileCredentialsProvider());
   }


### PR DESCRIPTION
Hi this should fix issues #14 

This will still work with instance credentials. if you look at the java sdk the ECS credential wrapper loads with the following conditionals

```java

            if (System.getenv(ECS_CONTAINER_CREDENTIALS_PATH) != null) {
                return new ContainerCredentialsProvider(new ECSCredentialsEndpointProvider());
            }
            if (System.getenv(CONTAINER_CREDENTIALS_FULL_URI) != null) {
                return new ContainerCredentialsProvider(new FullUriCredentialsEndpointProvider());
            }
            return InstanceProfileCredentialsProvider.getInstance();

```

And falls back to what you already had.

I have tested running this in our environment and it worked like a charm.

-Jeff