### PR TITLE
Bump jackson due to security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
     <java.source.encoding>${general.encoding}</java.source.encoding>
     <aws-java-sdk.version>1.11.384</aws-java-sdk.version>
     <logback.version>1.2.3</logback.version>
-    <jackson.version>2.9.2</jackson.version>
+    <jackson.version>2.9.5</jackson.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
There is a security issue in jackson-databind <= 2.9.4. This bumps us to the patched version.

https://nvd.nist.gov/vuln/detail/CVE-2018-7489