### PR TITLE
use latest java sdk for AWS to prevent snyk netty issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <!-- JAVA -->
     <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
-    <aws-java-sdk.version>2.10.11</aws-java-sdk.version>
+    <aws-java-sdk.version>2.16.69</aws-java-sdk.version>
     <logback.version>1.2.3</logback.version>
     <jackson.version>2.12.2</jackson.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>com.gu</groupId>
   <artifactId>kinesis-logback-appender</artifactId>
-  <version>2.0.3-SNAPSHOT</version>
+  <version>2.0.3</version>
 
   <name>LOGBack Appender for pushing logs to Kinesis</name>
   <description>This is an implementation of the AWS - Labs log4j appender for LOGBack.</description>
@@ -37,7 +37,7 @@
   <scm>
     <connection>scm:git:https://github.com/guardian/kinesis-logback-appender</connection>
     <developerConnection>scm:git:git@github.com:guardian/kinesis-logback-appender.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>kinesis-logback-appender-2.0.3</tag>
     <url>https://github.com/guardian/kinesis-logback-appender</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>com.gu</groupId>
   <artifactId>kinesis-logback-appender</artifactId>
-  <version>2.0.3</version>
+  <version>2.0.4-SNAPSHOT</version>
 
   <name>LOGBack Appender for pushing logs to Kinesis</name>
   <description>This is an implementation of the AWS - Labs log4j appender for LOGBack.</description>
@@ -37,7 +37,7 @@
   <scm>
     <connection>scm:git:https://github.com/guardian/kinesis-logback-appender</connection>
     <developerConnection>scm:git:git@github.com:guardian/kinesis-logback-appender.git</developerConnection>
-    <tag>kinesis-logback-appender-2.0.3</tag>
+    <tag>HEAD</tag>
     <url>https://github.com/guardian/kinesis-logback-appender</url>
   </scm>
 


### PR DESCRIPTION
This PR bumps the AWS client from an ancient one to the latest, which will pull in a remotely recent version of netty epoll
https://mvnrepository.com/artifact/software.amazon.awssdk/netty-nio-client

this will fix this https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-1082238
once we pull it into members-data-api.