### PR TITLE
Update AWS SDK to 2.17, which drops external jackson requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,29 +224,6 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
     </dependency>
-
-    <!--
-      Pull in an updated version of jackson libraries as the one's AWS use have security vulnerabilities.
-      We cannot simply update the AWS libraries as jackson 2.7+ doesn't support java6 and the AWS libraries compile to java6.
-      See https://github.com/aws/aws-sdk-java/pull/1373
-    -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
   </dependencies>
 
   <properties>
@@ -255,9 +232,8 @@
     <!-- JAVA -->
     <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
-    <aws-java-sdk.version>2.16.69</aws-java-sdk.version>
+    <aws-java-sdk.version>2.17.248</aws-java-sdk.version>
     <logback.version>1.2.3</logback.version>
-    <jackson.version>2.12.2</jackson.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
## What does this change?
AWS SDK for Java 2.17.x has [dropped its external dependency on Jackson](https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-2-17-removes-its-external-dependency-on-jackson/). This means that by updating to 2.17.x we can control the version of Jackson that is used in projects more independently. 

As it happens, the current version of the SDK in this project pulls in an old version of Jackson as well, which would mean projects keeping up to date with the latest Jackson would've had to override SDK versions in their project. 

## How to test
Ran `mvn install`. Installed the snapshot in a local application and observed log shipping via kinesis as expected.

## Have we considered potential risks?
Because of the change in dependency requirements that this change will bring into consuming projects, I'll release this as a minor version, rather than merely patch.