### PR TITLE
Upgrading logback to 1.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
     <aws-java-sdk.version>2.17.248</aws-java-sdk.version>
-    <logback.version>1.2.3</logback.version>
+    <logback.version>1.4.4</logback.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
## What does this change?

This bumps the underlying logback version from 1.2.3 to 1.4.4 (the latest at the time of this PR).

There are extensive fixes and security improvements since 1.2.3 - the full logback release notes are here:
https://logback.qos.ch/news.html


## How to test

This change was tested with a locally published version and used in Ophan. 
As this a library, other projects should run their tests when upgrading to this latest release.

## How can we measure success?

Continued kinesis logging functionality

## Have we considered potential risks?

The upgrade risk is small - existing projects can choose to use earlier versions

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
