### PR TITLE
Bump `aws-java-sdk` to 2.21.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
     <!-- JAVA -->
     <java.version>1.8</java.version>
     <java.source.encoding>${general.encoding}</java.source.encoding>
-    <aws-java-sdk.version>2.17.248</aws-java-sdk.version>
+    <aws-java-sdk.version>2.21.28</aws-java-sdk.version>
     <logback.version>1.4.4</logback.version>
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
   </properties>


### PR DESCRIPTION

## What does this change?

Bump `aws-java-sdk` to 2.20.162 to fix vulnerabilities
